### PR TITLE
BUG: void elements do not automatically self close

### DIFF
--- a/src/parser.constants.ts
+++ b/src/parser.constants.ts
@@ -1,0 +1,1 @@
+export const VOID_ELEMENTS = new Set(['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'source', 'track', 'wbr']);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,4 +1,4 @@
-import { Dictionary, Index, invariant } from 'ts-runtime-typecheck';
+import { assertDefined, Dictionary, Index, invariant } from 'ts-runtime-typecheck';
 import { append_attribute, append_child, close_parser, consume_whitespace, create_parser, get_attribute_value, parse_attributes, parse_chunk, parse_closing_tag, parse_node, parse_nodes, parse_opening_tag, parse_tag, parse_text_node, read_label } from './parser';
 import type { Parser } from './Parser.type';
 import { FRAGMENT_TAG } from './Template.constants';
@@ -731,33 +731,32 @@ describe('append_child', () => {
 });
 
 describe('append_attribute', () => {
-  test('throws if empty stack', () => {
-    const ctx = create_parser();
-    ctx.stack.length = 0;
-    expect(() => append_attribute(ctx, 'test', 'value')).toThrow('Stack is empty, no root node');
-  });
   test('creates attributes if it does not exist', () => {
     const ctx = create_parser();
-    expect(ctx.stack[0]?.attributes).toBeUndefined();
-    append_attribute(ctx, 'test', 'value');
-    expect(ctx.stack[0]?.attributes).toBeDefined();
+    const top = ctx.stack[0];
+    assertDefined(top);
+    expect(top.attributes).toBeUndefined();
+    append_attribute(top, 'test', 'value');
+    expect(top.attributes).toBeDefined();
   });
   test('uses existing attributes if already exists', () => {
     const ctx = create_parser();
     const top = ctx.stack[0];
-    invariant(typeof top !== 'undefined', '');
+    assertDefined(top);
 
     expect(top.attributes).toBeUndefined();
     const attr: Dictionary<Index> = {};
     top.attributes = attr;
 
-    append_attribute(ctx, 'test', 'value');
+    append_attribute(top, 'test', 'value');
     expect(attr['test']).toBe('value');
   });
   test('adds new attribute', () => {
     const ctx = create_parser();
-    append_attribute(ctx, 'a', 1);
-    append_attribute(ctx, 'b', 2);
+    const top = ctx.stack[0];
+    assertDefined(top);
+    append_attribute(top, 'a', 1);
+    append_attribute(top, 'b', 2);
     expect(ctx.stack[0]?.attributes).toStrictEqual({
       a: 1,
       b: 2
@@ -765,11 +764,13 @@ describe('append_attribute', () => {
   });
   test('overwrites an existing attribute with same name', () => {
     const ctx = create_parser();
-    append_attribute(ctx, 'a', 1);
+    const top = ctx.stack[0];
+    assertDefined(top);
+    append_attribute(top, 'a', 1);
     expect(ctx.stack[0]?.attributes).toStrictEqual({
       a: 1,
     });
-    append_attribute(ctx, 'a', 2);
+    append_attribute(top, 'a', 2);
     expect(ctx.stack[0]?.attributes).toStrictEqual({
       a: 2,
     });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -606,6 +606,26 @@ describe('parse_opening_tag', () => {
       });
       expect(buffer.length).toBe(0);
     });
+    test('void tag', () => {
+      const ctx = create_parser();
+      const buffer = Array.from('img>');
+      parse_opening_tag(ctx, buffer);
+      expect(ctx.stack[0]).toStrictEqual({
+        tag: FRAGMENT_TAG,
+        children: [{ tag: 'img' }]
+      });
+      expect(buffer.length).toBe(0);
+    });
+    test('void tag with self closing', () => {
+      const ctx = create_parser();
+      const buffer = Array.from('img/>');
+      parse_opening_tag(ctx, buffer);
+      expect(ctx.stack[0]).toStrictEqual({
+        tag: FRAGMENT_TAG,
+        children: [{ tag: 'img' }]
+      });
+      expect(buffer.length).toBe(0);
+    });
     test('with attribute', () => {
       const ctx = create_parser();
       const buffer = Array.from('hello test="value">');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,5 @@
 import { invariant } from 'ts-runtime-typecheck';
+import { VOID_ELEMENTS } from './parser.constants';
 import type { Parser } from './Parser.type';
 import { FRAGMENT_TAG } from './Template.constants';
 import type { Template } from './Template.type';
@@ -70,6 +71,10 @@ export function parse_attributes (ctx: Parser, buffer: string[]): void {
     // consume '/'
     buffer.shift();
     // pop the current element from the stack
+    ctx.stack.shift();
+  }
+  // void elements self close without the slash
+  else if (VOID_ELEMENTS.has(top.tag)) {
     ctx.stack.shift();
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -30,6 +30,8 @@ export function parse_chunk (ctx: Parser, src: string, part_index: number) {
 }
 
 export function parse_attributes (ctx: Parser, buffer: string[]): void {
+  const top = ctx.stack[0];
+  invariant(top !== undefined, 'Stack is empty, no root node');
   do {
     consume_whitespace(buffer);
     if (buffer[0] === '/' || buffer[0] === '>') {
@@ -51,9 +53,9 @@ export function parse_attributes (ctx: Parser, buffer: string[]): void {
       // consume "="
       buffer.shift();
       const value = get_attribute_value(ctx, buffer);
-      append_attribute(ctx, name, value);
+      append_attribute(top, name, value);
     } else {
-      append_attribute(ctx, name, '');
+      append_attribute(top, name, '');
     }
   } while(buffer.length > 0);
 
@@ -208,9 +210,7 @@ export function append_child (ctx: Parser, child: string | number | Template) {
   children.push(child);
 }
 
-export function append_attribute(ctx: Parser, name: string, child: string | number) {
-  const top = ctx.stack[0];
-  invariant(top !== undefined, 'Stack is empty, no root node');
+export function append_attribute(top: Template, name: string, child: string | number) {
   let attributes = top.attributes;
   if (!attributes) {
     attributes = {};


### PR DESCRIPTION
Closes #1 

Adds a list of void elements as defined by https://html.spec.whatwg.org/multipage/syntax.html#void-elements 

Any opening tag which is a void element is implicitly self closing.